### PR TITLE
Fix: Duplicate chat messages

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -117,18 +117,17 @@ class ChatController extends Controller
 
         return response()->stream(function () use ($request, $chat) {
             $messages = collect($request->input('messages', []));
-            $messageType = $request->string('messageType', 'prompt');
-            $messageContent = $request->string('messageContent')->trim()->value();
+            $prompt = $request->string('prompt')->trim()->value();
 
-            if ($messages->isEmpty() && empty($messageContent)) {
+            if ($messages->isEmpty() && empty($prompt)) {
                 return;
             }
 
             // Only save/load messages if we have an existing chat (authenticated user with saved chat)
-            if ($chat && $messageContent && Auth::check()) {
+            if ($chat && $prompt && Auth::check()) {
                 $chat->messages()->create([
-                    'type' => $messageType,
-                    'content' => $messageContent,
+                    'type' => 'prompt',
+                    'content' => $prompt,
                 ]);
                 $messages = $chat->messages()->orderBy('created_at')->get();
             }

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -120,7 +120,7 @@ class ChatController extends Controller
             $prompt = $request->string('prompt')->trim()->value();
             $autoStream = $request->input('autoStream', false);
 
-            if ($messages->isEmpty() && empty($prompt)) {
+            if ($messages->isEmpty() && empty($prompt) && ! $autoStream) {
                 return;
             }
 

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -120,6 +120,10 @@ class ChatController extends Controller
             $messageType = $request->string('messageType', 'prompt');
             $messageContent = $request->string('messageContent')->trim()->value();
 
+            if ($messages->isEmpty() && empty($messageContent)) {
+                return;
+            }
+
             // Only save/load messages if we have an existing chat (authenticated user with saved chat)
             if ($chat && $messageContent && Auth::check()) {
                 $chat->messages()->create([

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -118,17 +118,20 @@ class ChatController extends Controller
         return response()->stream(function () use ($request, $chat) {
             $messages = collect($request->input('messages', []));
             $prompt = $request->string('prompt')->trim()->value();
+            $autoStream = $request->input('autoStream', false);
 
             if ($messages->isEmpty() && empty($prompt)) {
                 return;
             }
 
             // Only save/load messages if we have an existing chat (authenticated user with saved chat)
-            if ($chat && $prompt && Auth::check()) {
-                $chat->messages()->create([
-                    'type' => 'prompt',
-                    'content' => $prompt,
-                ]);
+            if ($chat && Auth::check()) {
+                if ($prompt && ! $autoStream) {
+                    $chat->messages()->create([
+                        'type' => 'prompt',
+                        'content' => $prompt,
+                    ]);
+                }
                 $messages = $chat->messages()->orderBy('created_at')->get();
             }
 

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -137,8 +137,7 @@ class ChatController extends Controller
             $openAIMessages = $messages->map(fn ($message) => [
                 'role' => $message['type'] === 'prompt' ? 'user' : 'assistant',
                 'content' => $message['content'],
-            ])
-            ->toArray();
+            ])->toArray();
 
             // Stream response from OpenAI
             $fullResponse = '';

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -116,32 +116,25 @@ class ChatController extends Controller
         }
 
         return response()->stream(function () use ($request, $chat) {
-            $messages = $request->input('messages', []);
+            $messages = collect($request->input('messages', []));
+            $messageType = $request->string('messageType', 'prompt');
+            $messageContent = $request->string('messageContent')->trim()->value();
 
-            if (empty($messages)) {
-                return;
-            }
-
-            // Only save messages if we have an existing chat (authenticated user with saved chat)
-            if ($chat) {
-                foreach ($messages as $message) {
-                    // Only save if message doesn't have an ID (not from database)
-                    if (! isset($message['id'])) {
-                        $chat->messages()->create([
-                            'type' => $message['type'],
-                            'content' => $message['content'],
-                        ]);
-                    }
-                }
+            // Only save/load messages if we have an existing chat (authenticated user with saved chat)
+            if ($chat && $messageContent && Auth::check()) {
+                $chat->messages()->create([
+                    'type' => $messageType,
+                    'content' => $messageContent,
+                ]);
+                $messages = $chat->messages()->orderBy('created_at')->get();
             }
 
             // Prepare messages for OpenAI
-            $openAIMessages = collect($messages)
-                ->map(fn ($message) => [
-                    'role' => $message['type'] === 'prompt' ? 'user' : 'assistant',
-                    'content' => $message['content'],
-                ])
-                ->toArray();
+            $openAIMessages = $messages->map(fn ($message) => [
+                'role' => $message['type'] === 'prompt' ? 'user' : 'assistant',
+                'content' => $message['content'],
+            ])
+            ->toArray();
 
             // Stream response from OpenAI
             $fullResponse = '';

--- a/resources/js/pages/chat.tsx
+++ b/resources/js/pages/chat.tsx
@@ -128,7 +128,10 @@ function ChatWithStream({ chat, auth, flash }: { chat: ChatType | undefined; aut
 
         // Send message data based on chat/auth status
         if (chat && auth.user) {
-            send({ messageType: 'prompt', messageContent: query});
+            send({
+                messageType: 'prompt',
+                messageContent: query,
+            });
         } else {
             send({ messages: [...messages, ...toAdd] });
         }

--- a/resources/js/pages/chat.tsx
+++ b/resources/js/pages/chat.tsx
@@ -61,7 +61,10 @@ function ChatWithStream({ chat, auth, flash }: { chat: ChatType | undefined; aut
 
         if (shouldAutoStream) {
             setTimeout(() => {
-                send({ messages: chat.messages });
+                const first = chat.messages[0];
+                if (first.type === 'prompt') {
+                    send({ prompt: first.content });
+                }
             }, 100);
         }
     }, [chat?.messages, flash?.stream, send]); // Only run on mount
@@ -128,10 +131,7 @@ function ChatWithStream({ chat, auth, flash }: { chat: ChatType | undefined; aut
 
         // Send message data based on chat/auth status
         if (chat && auth.user) {
-            send({
-                messageType: 'prompt',
-                messageContent: query,
-            });
+            send({ prompt: query });
         } else {
             send({ messages: [...messages, ...toAdd] });
         }

--- a/resources/js/pages/chat.tsx
+++ b/resources/js/pages/chat.tsx
@@ -63,7 +63,7 @@ function ChatWithStream({ chat, auth, flash }: { chat: ChatType | undefined; aut
             setTimeout(() => {
                 const first = chat.messages[0];
                 if (first.type === 'prompt') {
-                    send({ prompt: first.content });
+                    send({ autoStream: 1 });
                 }
             }, 100);
         }

--- a/resources/js/pages/chat.tsx
+++ b/resources/js/pages/chat.tsx
@@ -126,8 +126,12 @@ function ChatWithStream({ chat, auth, flash }: { chat: ChatType | undefined; aut
         // Update local state
         setMessages((prev) => [...prev, ...toAdd]);
 
-        // Send all messages including the new ones
-        send({ messages: [...messages, ...toAdd] });
+        // Send message data based on chat/auth status
+        if (chat && auth.user) {
+            send({ messageType: 'prompt', messageContent: query});
+        } else {
+            send({ messages: [...messages, ...toAdd] });
+        }
 
         input.value = '';
         inputRef.current?.focus();

--- a/tests/Feature/ChatFlowTest.php
+++ b/tests/Feature/ChatFlowTest.php
@@ -64,9 +64,7 @@ class ChatFlowTest extends TestCase
 
         // Now send the message to the new chat
         $response = $this->post("/chat/{$chat->id}/stream", [
-            'messages' => [
-                ['type' => 'prompt', 'content' => 'Hello from home page'],
-            ],
+            'prompt' => 'Hello from home page',
         ]);
 
         $response->assertStatus(200);

--- a/tests/Feature/ChatStreamingTest.php
+++ b/tests/Feature/ChatStreamingTest.php
@@ -34,9 +34,7 @@ class ChatStreamingTest extends TestCase
         $chat = Chat::factory()->create(['user_id' => $user->id]);
 
         $response = $this->actingAs($user)->post("/chat/{$chat->id}/stream", [
-            'messages' => [
-                ['type' => 'prompt', 'content' => 'Hello AI'],
-            ],
+            'prompt' => 'Hello AI',
         ]);
 
         $response->assertStatus(200);
@@ -67,43 +65,6 @@ class ChatStreamingTest extends TestCase
 
         $response->assertStatus(200);
         $this->assertDatabaseCount('messages', 0);
-    }
-
-    public function test_messages_marked_as_saved_are_not_duplicated(): void
-    {
-        $user = User::factory()->create();
-        $chat = Chat::factory()->create(['user_id' => $user->id]);
-
-        // Create existing message
-        $existingMessage = Message::factory()->create([
-            'chat_id' => $chat->id,
-            'type' => 'prompt',
-            'content' => 'Already saved',
-        ]);
-
-        $response = $this->actingAs($user)->post("/chat/{$chat->id}/stream", [
-            'messages' => [
-                ['id' => $existingMessage->id, 'type' => 'prompt', 'content' => 'Already saved'],
-                ['type' => 'prompt', 'content' => 'New message'],
-            ],
-        ]);
-
-        $response->assertStatus(200);
-
-        // Get the streaming content
-        $response->streamedContent();
-
-        // Verify only the new message was saved (1 existing + 1 new prompt + 1 AI response)
-        $this->assertDatabaseCount('messages', 3);
-        $this->assertDatabaseHas('messages', [
-            'chat_id' => $chat->id,
-            'content' => 'New message',
-        ]);
-        $this->assertDatabaseHas('messages', [
-            'chat_id' => $chat->id,
-            'type' => 'response',
-            'content' => 'This is a test response.',
-        ]);
     }
 
     public function test_chat_not_created_for_anonymous_users(): void


### PR DESCRIPTION
## About
Previously, the `stream()` controller method relied on the client to send the full conversation history back to the server for both authenticated and guest users. On each authenticated request (Chat exists), the server would re-save any messages without an id. With this design if a user had an existing chat and refreshed the page, the client re-sent all messages from state. The backend then persisted those messages again, resulting in duplicated messages being stored in the database.

This PR makes the database the source of truth for chat history of authenticated users, while still allowing the full message context to be sent for guests/anonymous chats.

## Demo
### Before
https://github.com/user-attachments/assets/81b55b65-a012-4f84-8957-9d22a7d0e04b  

### After
https://github.com/user-attachments/assets/48fbc58b-7eab-438d-96f0-3b307819c33e  